### PR TITLE
Handles client-side steam name for lobby

### DIFF
--- a/Assets/Scripts/Networking/RTSNetworkManager.cs
+++ b/Assets/Scripts/Networking/RTSNetworkManager.cs
@@ -72,12 +72,18 @@ namespace Networking
 
             var player = conn.identity.GetComponent<RTSPlayer>();
             Players.Add(player.GetUUID(), player);
+            if (useSteam && SteamManager.Initialized)
+            {
+                if (NetworkServer.active)
+                {
+                    player.SetDisplayName(SteamFriends.GetPersonaName());
+                }
+            }
+            else
+            {
+                player.SetDisplayName($"Player {Players.Count}");
+            }
 
-            player.SetDisplayName(
-                useSteam && SteamManager.Initialized
-                  ? SteamFriends.GetPersonaName()
-                  : $"Player {Players.Count}"
-            );
             player.SetTeamColor(
                 new Color(Random.Range(0f, 1f), Random.Range(0f, 1f), Random.Range(0f, 1f))
             );


### PR DESCRIPTION
Steam support is still pretty hacky, but this allows the clients to have the correct name 